### PR TITLE
chore: añadir INTERNAL_SPEAKER y INTERNAL_GATEWAY al .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ INTERNAL_INFERENCE_ID=InferenceCenter
 INTERNAL_INFERENCE_KEY=change_this_secure_key
 INTERNAL_TRANSCRIPTOR_ID=Transcriptor
 INTERNAL_TRANSCRIPTOR_KEY=change_this_secure_key
+INTERNAL_SPEAKER_ID=JotaSpeaker
+INTERNAL_SPEAKER_KEY=change_this_secure_key
+INTERNAL_GATEWAY_ID=JotaGateway
+INTERNAL_GATEWAY_KEY=change_this_secure_key
 
 MODELS_DIR=/app/models
 HOST_MODELS_DIR=/path/on/host/to/models


### PR DESCRIPTION
## Summary

- Añade `INTERNAL_SPEAKER_ID` / `INTERNAL_SPEAKER_KEY` al `.env.example`
- Añade `INTERNAL_GATEWAY_ID` / `INTERNAL_GATEWAY_KEY` al `.env.example`
- Estos servicios ya existían en `bootstrap_system_clients()` pero faltaban en el ejemplo de configuración

## Test plan

- [x] Copiar `.env.example` a `.env` y verificar que el bootstrap arranca sin warnings de credenciales faltantes para Speaker y Gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)