### PR TITLE
chore: registrar Speaker y Gateway en bootstrap_system_clients

### DIFF
--- a/src/core/database.py
+++ b/src/core/database.py
@@ -44,7 +44,16 @@ def bootstrap_system_clients(session: Session):
         {
             "id": os.getenv("INTERNAL_TRANSCRIPTOR_ID"),
             "key": os.getenv("INTERNAL_TRANSCRIPTOR_KEY")
+        },
+        {
+            "id": os.getenv("INTERNAL_SPEAKER_ID"),
+            "key": os.getenv("INTERNAL_SPEAKER_KEY")
+        },
+        {
+            "id": os.getenv("INTERNAL_GATEWAY_ID"),
+            "key": os.getenv("INTERNAL_GATEWAY_KEY")
         }
+
     ]
 
     print("🚀 Verificando servicios internos (Bootstrap)...")


### PR DESCRIPTION
## Summary

- Añade `INTERNAL_SPEAKER_ID/KEY` e `INTERNAL_GATEWAY_ID/KEY` al array de servicios en `bootstrap_system_clients()`
- Sin esto, aunque las variables estén en `.env`, los servicios no se crean en la DB al arrancar

## Relacionado

Complementa #13 (`.env.example`)

## Test plan

- [ ] Arrancar con `docker compose up --build -d` y verificar en logs que Speaker y Gateway aparecen en el bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)