### PR TITLE
docs(db): mark as Deprecated, move Tasks/Events to legacy doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,276 +1,42 @@
-# Cerebro Digital - Guía de Uso
+# jota-db
 
-## 🚀 Inicio Rápido
+![Status: Deprecated](https://img.shields.io/badge/status-Deprecated-red)
 
-### 1. Levantar los servicios
+> ⚠️ **Deprecated as identity/config source.** As of `jota-gateway` v1.9.0, the gateway maintains its own SQLite database for client identity and configuration. `jota-db` is kept for compatibility with setups that still use it as a centralized auth backend for `jota-transcriber` and `jota-speaker`.
+>
+> See [org ARCHITECTURE.md](https://github.com/Jota-project/.github/blob/main/ARCHITECTURE.md) §10 for the full deprecation context.
 
-```bash
-# Asegúrate de que Docker está corriendo
-docker compose up --build -d
+---
 
-# Ver logs
-docker compose logs -f api-server
-```
+## Current role
 
-### 2. Verificar que todo funciona
+`jota-db` provides:
 
-```bash
-# Health check
-curl http://localhost:8000/health
+- **Centralized auth API** for legacy service setups (transcriber, speaker, others) via `AUTH_API_URL` + `AUTH_API_SECRET`.
+- **Admin REST API** (`/admin/services`, `/admin/clients`, `/admin/providers`, `/admin/config`) for managing `ServiceConfig`, `InferenceProvider`, `AdminUser`, and `Client`/`ClientConfig`.
+- **Internal REST API** (`/internal/`) for service-to-service configuration and provider queries.
 
-# Deberías ver: {"status":"ok","service":"Cerebro Digital API"}
-```
+## Migration direction
 
-## 📝 Ejemplos de Uso de la API
+The dependency on `jota-db` for client identity is removed in `jota-gateway`. The remaining dependencies (`jota-transcriber` and `jota-speaker` using it as external auth) are tracked in [`Jota-project/jota-gateway` issues](https://github.com/Jota-project/jota-gateway/issues) under the deprecation effort.
 
-### Tasks (Tareas)
+If you maintain a fresh deployment:
+- **Don't** use `jota-db` as identity source.
+- For local auth per service, use `AUTH_TOKEN` static.
+- For centralized auth, you can still use `jota-db` until the migration is complete.
 
-#### Crear una tarea
-```bash
-curl -X POST http://localhost:8000/tasks \
-  -H "Content-Type: application/json" \
-  -d '{
-    "title": "Preparar presentación",
-    "status": "pending",
-    "priority": 4,
-    "timing_relative_to_event": "before"
-  }'
-```
+## Components
 
-#### Listar todas las tareas
-```bash
-curl http://localhost:8000/tasks
-```
+| Component | Path |
+| :--- | :--- |
+| All data models | `src/core/models.py` |
+| Bearer security | `src/api/security.py` |
+| Auth endpoints (`/auth/client`, `/auth/validate`) | `src/api/routers/auth.py` |
+| Config endpoints (`/config/me`) | `src/api/routers/config.py` |
+| Chat (conversations, messages) | `src/api/routers/chat.py` |
+| Admin routers (`/admin/services`, `/admin/clients`, `/admin/providers`, `/admin/config`) | `src/api/routers/admin/` |
+| Internal routers (`/internal/`) | `src/api/routers/internal/` |
 
-#### Filtrar tareas por estado
-```bash
-curl "http://localhost:8000/tasks?status_filter=pending"
-```
+## Historical
 
-#### Actualizar una tarea (con optimistic locking)
-```bash
-# Primero obtén la tarea para conocer su versión actual
-curl http://localhost:8000/tasks/1
-
-# Luego actualiza incluyendo la versión
-curl -X PATCH http://localhost:8000/tasks/1 \
-  -H "Content-Type: application/json" \
-  -d '{
-    "status": "done",
-    "version": 1
-  }'
-```
-
-#### Eliminar una tarea
-```bash
-curl -X DELETE http://localhost:8000/tasks/1
-```
-
-### Events (Eventos)
-
-#### Crear un evento
-```bash
-curl -X POST http://localhost:8000/events \
-  -H "Content-Type: application/json" \
-  -d '{
-    "title": "Reunión con el equipo",
-    "description": "Sprint planning Q1 2026",
-    "start_at": "2026-02-05T10:00:00",
-    "end_at": "2026-02-05T11:30:00",
-    "location": "Sala de conferencias"
-  }'
-```
-
-#### Listar eventos
-```bash
-curl http://localhost:8000/events
-```
-
-#### Filtrar eventos por rango de fechas
-```bash
-curl "http://localhost:8000/events?start_after=2026-02-01T00:00:00&start_before=2026-02-28T23:59:59"
-```
-
-### Reminders (Recordatorios)
-
-#### Crear un recordatorio vinculado a una tarea
-```bash
-curl -X POST http://localhost:8000/reminders \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Revisar slides de la presentación",
-    "trigger_at": "2026-02-04T18:00:00",
-    "task_id": 1
-  }'
-```
-
-#### Crear un recordatorio independiente
-```bash
-curl -X POST http://localhost:8000/reminders \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Llamar al dentista",
-    "trigger_at": "2026-02-03T09:00:00"
-  }'
-```
-
-#### Listar recordatorios pendientes
-```bash
-curl "http://localhost:8000/reminders?is_completed=false"
-```
-
-### Auth (Autenticación)
-
-#### Validar servicio interno (InternalService)
-```bash
-curl "http://localhost:8000/auth/internal" \
-  -H "X-Service-ID: JotaOrchestrator" \
-  -H "X-API-Key: secret123" \
-  -H "Authorization: Bearer <API_SECRET_KEY>"
-```
-
-#### Validar cliente externo (Client)
-```bash
-curl "http://localhost:8000/auth/client" \
-  -H "X-API-Key: desktop_client_01" \
-  -H "Authorization: Bearer <API_SECRET_KEY>"
-```
-
-### Chat (Conversación)
-
-#### Iniciar una conversación
-```bash
-curl -X POST http://localhost:8000/chat/conversation \
-  -H "Content-Type: application/json" \
-  -d '{
-    "client_id": 1,
-    "title": "Ayuda con Python"
-  }'
-```
-
-#### Enviar un mensaje
-```bash
-curl -X POST http://localhost:8000/chat/1/messages \
-  -H "Content-Type: application/json" \
-  -d '{
-    "role": "user",
-    "content": "¿Cómo funciona asyncio?"
-  }'
-```
-
-#### Obtener mensajes de una conversación
-```bash
-curl http://localhost:8000/chat/1/messages
-
-# Con límite de mensajes
-curl "http://localhost:8000/chat/1/messages?limit=10"
-```
-
-## 🔒 Optimistic Locking (Control de Concurrencia)
-
-El sistema implementa **optimistic locking** para prevenir conflictos cuando múltiples servicios (API + futuro MCP) modifican los mismos datos.
-
-### ¿Cómo funciona?
-
-Cada registro tiene un campo `version` que se incrementa automáticamente en cada actualización.
-
-### Ejemplo de conflicto detectado
-
-```bash
-# Usuario A obtiene la tarea (version=1)
-curl http://localhost:8000/tasks/1
-# {"id":1,"title":"Mi tarea","version":1,...}
-
-# Usuario B también obtiene la tarea (version=1)
-curl http://localhost:8000/tasks/1
-
-# Usuario A actualiza primero (version pasa a 2)
-curl -X PATCH http://localhost:8000/tasks/1 \
-  -H "Content-Type: application/json" \
-  -d '{"status":"doing","version":1}'
-
-# Usuario B intenta actualizar con version=1 (¡CONFLICTO!)
-curl -X PATCH http://localhost:8000/tasks/1 \
-  -H "Content-Type: application/json" \
-  -d '{"priority":5,"version":1}'
-
-# Respuesta: HTTP 409 Conflict
-# {"detail":"Version conflict: expected 2, got 1"}
-```
-
-### Buenas prácticas
-
-1. **Siempre incluye el campo `version`** en tus actualizaciones
-2. Si recibes un error 409, **vuelve a obtener el registro** actualizado
-3. Revisa los cambios y **reaplica tu modificación** con la nueva versión
-
-## 🗄️ Arquitectura de Base de Datos
-
-### Connection Pool
-
-El sistema está configurado para manejar múltiples servicios concurrentes:
-
-- **pool_size**: 10 conexiones base
-- **max_overflow**: 20 conexiones adicionales bajo carga
-- **pool_recycle**: Recicla conexiones cada hora
-
-### Índices de Performance
-
-Se han creado índices en los campos más consultados:
-
-- **Tasks**: `status`, `priority`, `event_id`
-- **Events**: `start_at`, `end_at`
-- **Reminders**: `trigger_at`, `task_id`, `event_id`, `is_completed`
-
-## 🐳 Docker
-
-### Comandos útiles
-
-```bash
-# Iniciar servicios
-docker compose up -d
-
-# Ver logs en tiempo real
-docker compose logs -f
-
-# Detener servicios
-docker compose down
-
-# Detener y eliminar volúmenes (¡CUIDADO! Borra la DB)
-docker compose down -v
-
-# Reconstruir después de cambios en el código
-docker compose up --build -d
-
-# Acceder a la base de datos
-docker exec -it jota_db psql -U user -d jota
-
-# Gestión de Migraciones (Alembic)
-# Generar una nueva migración (después de cambiar modelos)
-docker compose exec api-server alembic revision --autogenerate -m "descripcion_cambios"
-
-# Aplicar migraciones pendientes
-docker compose exec api-server alembic upgrade head
-```
-
-### Seguridad
-
-El contenedor de la API:
-
-- ✅ Usa **Alpine Linux** (imagen mínima)
-- ✅ **Multi-stage build** (reduce tamaño)
-- ✅ Ejecuta como **usuario no-root** (`appuser`)
-- ✅ Health checks configurados
-
-## 📚 Próximos Pasos
-
-1. **Implementar el servidor MCP** para integración con IAs
-2. **Añadir autenticación** (JWT tokens)
-3. **Crear tests automatizados** (pytest)
-4. **Documentación automática** con Swagger UI (ya disponible en `/docs`)
-
-## 🔗 Endpoints Útiles
-
-- **API Docs (Swagger)**: http://localhost:8000/docs
-- **ReDoc**: http://localhost:8000/redoc
-- **Health Check**: http://localhost:8000/health
+The Tasks/Events API documented in early iterations of this repo is no longer part of the active system. See [`docs/legacy-tasks-api.md`](docs/legacy-tasks-api.md) for the historical surface, kept only for reference.

--- a/docs/legacy-tasks-api.md
+++ b/docs/legacy-tasks-api.md
@@ -1,0 +1,79 @@
+# Legacy Tasks & Events API
+
+> ⚠️ **DEPRECATED.** This API surface was part of an earlier iteration of `jota-db`. It is no longer part of the active system and is kept here only for historical reference and to support external integrations that may still call it.
+
+The endpoints documented below (`/tasks`, `/events`) are present in some older deployments but are not part of the current Jota architecture. The current role of `jota-db` is centralized authentication for legacy service setups — see the [main README](../README.md).
+
+---
+
+## Tasks (legacy)
+
+### Tasks (Tareas)
+
+#### Crear una tarea
+```bash
+curl -X POST http://localhost:8000/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Preparar presentación",
+    "status": "pending",
+    "priority": 4,
+    "timing_relative_to_event": "before"
+  }'
+```
+
+#### Listar todas las tareas
+```bash
+curl http://localhost:8000/tasks
+```
+
+#### Filtrar tareas por estado
+```bash
+curl "http://localhost:8000/tasks?status_filter=pending"
+```
+
+#### Actualizar una tarea (con optimistic locking)
+```bash
+# Primero obtén la tarea para conocer su versión actual
+curl http://localhost:8000/tasks/1
+
+# Luego actualiza incluyendo la versión
+curl -X PATCH http://localhost:8000/tasks/1 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "status": "done",
+    "version": 1
+  }'
+```
+
+#### Eliminar una tarea
+```bash
+curl -X DELETE http://localhost:8000/tasks/1
+```
+
+## Events (legacy)
+
+### Events (Eventos)
+
+#### Crear un evento
+```bash
+curl -X POST http://localhost:8000/events \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Reunión con el equipo",
+    "description": "Sprint planning Q1 2026",
+    "start_at": "2026-02-05T10:00:00",
+    "end_at": "2026-02-05T11:30:00",
+    "location": "Sala de conferencias"
+  }'
+```
+
+#### Listar eventos
+```bash
+curl http://localhost:8000/events
+```
+
+#### Filtrar eventos por rango de fechas
+```bash
+curl "http://localhost:8000/events?start_after=2026-02-01T00:00:00&start_before=2026-02-28T23:59:59"
+```


### PR DESCRIPTION
Marca jota-db como Deprecated (gateway ya tiene SQLite local). Mueve la sección Tasks/Events a docs/legacy-tasks-api.md con banner de deprecated. El README principal ahora describe el rol real (auth centralizada + routers admin/internal).

**Nota para el revisor:** este PR reemplaza el README completo, no solo la sección Tasks/Events. Contenido que también se elimina y no queda archivado en ningún sitio: ejemplos curl de Reminders/Auth/Chat, guía de Optimistic Locking, notas de arquitectura de DB/connection pool, comandos Docker, y las secciones 'Próximos Pasos'/'Endpoints Útiles'. Si algo de eso sigue siendo útil, decidme y lo recupero en un doc aparte antes de mergear.